### PR TITLE
Auto-load bundled dataset

### DIFF
--- a/aquatrack.js
+++ b/aquatrack.js
@@ -433,7 +433,9 @@ function handleFiles(files, photosBaseOverride) {
 
 function handleDrop(event) {
   event.preventDefault();
-  dropOverlay.hidden = true;
+  if (dropOverlay) {
+    dropOverlay.hidden = true;
+  }
   const baseParam = new URLSearchParams(window.location.search).get('base') ?? undefined;
   handleFiles(event.dataTransfer.files, baseParam);
 }
@@ -441,12 +443,14 @@ function handleDrop(event) {
 function handleDragEnter(event) {
   if (event.dataTransfer?.items?.length) {
     event.preventDefault();
-    dropOverlay.hidden = false;
+    if (dropOverlay) {
+      dropOverlay.hidden = false;
+    }
   }
 }
 
 function handleDragLeave(event) {
-  if (event.target === dropOverlay) {
+  if (dropOverlay && event.target === dropOverlay) {
     dropOverlay.hidden = true;
   }
 }
@@ -506,15 +510,21 @@ function init() {
     const storedFile = localStorage.getItem(LAST_FILE_KEY);
     if (storedUrl) {
       loadFromUrl(storedUrl, baseParam);
-    } else if (storedFile) {
+      return;
+    }
+
+    if (storedFile) {
       try {
         const json = JSON.parse(storedFile);
         render(json, { photosBase: baseParam });
         setStatus('Loaded most recent local file.', 'success');
+        return;
       } catch (error) {
         console.error(error);
       }
     }
+
+    loadFromUrl('aquatrack.json', baseParam);
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -17,14 +17,16 @@
       <div class="wrap">
         <h1>🐟 FishTankTracker</h1>
         <p class="tagline">
-          Load any <code>aquatrack.json</code> file to explore your aquarium history.
-          Everything runs in your browser – no login, no uploads.
+          Explore your aquarium history right away with the bundled
+          <code>aquatrack.json</code>. Everything runs in your browser – no login,
+          no uploads.
         </p>
         <div class="controls" role="group" aria-label="Data loading controls">
-          <button id="loadButton" type="button" class="btn primary">Load JSON</button>
+          <button id="loadButton" type="button" class="btn primary">
+            Load different JSON
+          </button>
           <input id="fileInput" type="file" accept="application/json" hidden />
           <button id="reloadButton" type="button" class="btn">Reload last file</button>
-          <span class="hint">Tip: drag &amp; drop a JSON file anywhere on the page.</span>
         </div>
         <div id="status" role="status" aria-live="polite"></div>
       </div>
@@ -32,18 +34,10 @@
 
     <main class="wrap" id="content" data-empty>
       <section class="placeholder">
-        <h2>Bring your tank to life</h2>
-        <ol>
-          <li>Click <strong>Load JSON</strong> and pick an <code>aquatrack.json</code>.</li>
-          <li>Or add <code>?data=aquatrack.json</code> to the URL to auto-load.</li>
-          <li>
-            Optional: add <code>&amp;base=/photos/</code> or set
-            <code>"photosBase"</code> inside the JSON for local photo folders.
-          </li>
-        </ol>
+        <h2>Loading your aquarium</h2>
         <p class="note">
-          Not sure where to start? Try the bundled
-          <a href="aquatrack.json" id="demoLink">sample data</a>.
+          The default <code>aquatrack.json</code> loads automatically. Use the
+          buttons above if you want to explore another file.
         </p>
       </section>
 
@@ -106,12 +100,6 @@
         <figcaption></figcaption>
       </figure>
     </template>
-
-    <div id="dropOverlay" hidden>
-      <div class="overlay-content">
-        <p>Drop your <code>aquatrack.json</code> to load it.</p>
-      </div>
-    </div>
 
     <script src="aquatrack.js" type="module"></script>
   </body>


### PR DESCRIPTION
## Summary
- automatically load the bundled `aquatrack.json` when no prior selection is stored
- update the landing copy to reflect the immediate data load and retitle the manual load action
- keep drag-and-drop functional while making the overlay optional

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e24e0eeb1083238a3147802af5861e