### PR TITLE
Simplify loading UI and refresh palette

### DIFF
--- a/aquatrack.js
+++ b/aquatrack.js
@@ -8,7 +8,6 @@ const residentsSection = document.getElementById('residentsSection');
 const measurementsSection = document.getElementById('measurementsSection');
 const eventsSection = document.getElementById('eventsSection');
 const photosSection = document.getElementById('photosSection');
-const dropOverlay = document.getElementById('dropOverlay');
 
 const LAST_URL_KEY = 'aquatrack:last-url';
 const LAST_FILE_KEY = 'aquatrack:last-file';
@@ -433,26 +432,8 @@ function handleFiles(files, photosBaseOverride) {
 
 function handleDrop(event) {
   event.preventDefault();
-  if (dropOverlay) {
-    dropOverlay.hidden = true;
-  }
   const baseParam = new URLSearchParams(window.location.search).get('base') ?? undefined;
   handleFiles(event.dataTransfer.files, baseParam);
-}
-
-function handleDragEnter(event) {
-  if (event.dataTransfer?.items?.length) {
-    event.preventDefault();
-    if (dropOverlay) {
-      dropOverlay.hidden = false;
-    }
-  }
-}
-
-function handleDragLeave(event) {
-  if (dropOverlay && event.target === dropOverlay) {
-    dropOverlay.hidden = true;
-  }
 }
 
 function reloadLast(photosBaseOverride) {
@@ -495,11 +476,9 @@ function init() {
 
   reloadButton.addEventListener('click', () => reloadLast(baseParam));
 
-  document.addEventListener('dragenter', handleDragEnter);
   document.addEventListener('dragover', (event) => {
     event.preventDefault();
   });
-  document.addEventListener('dragleave', handleDragLeave);
   document.addEventListener('drop', handleDrop);
 
   if (dataParam) {

--- a/index.html
+++ b/index.html
@@ -16,11 +16,7 @@
     <header class="site-header">
       <div class="wrap">
         <h1>🐟 FishTankTracker</h1>
-        <p class="tagline">
-          Explore your aquarium history right away with the bundled
-          <code>aquatrack.json</code>. Everything runs in your browser – no login,
-          no uploads.
-        </p>
+        <p class="tagline">Your aquatic memories, beautifully organized.</p>
         <div class="controls" role="group" aria-label="Data loading controls">
           <button id="loadButton" type="button" class="btn primary">
             Load different JSON
@@ -34,11 +30,8 @@
 
     <main class="wrap" id="content" data-empty>
       <section class="placeholder">
-        <h2>Loading your aquarium</h2>
-        <p class="note">
-          The default <code>aquatrack.json</code> loads automatically. Use the
-          buttons above if you want to explore another file.
-        </p>
+        <h2>Ready when you are</h2>
+        <p class="note">Load any tank journal to reveal its story.</p>
       </section>
 
       <section id="tankSection" class="panel" hidden>

--- a/styles.css
+++ b/styles.css
@@ -1,26 +1,23 @@
 :root {
-  color-scheme: light dark;
-  --bg: #f5f7fb;
-  --panel-bg: #ffffffcc;
-  --panel-border: rgba(17, 24, 39, 0.1);
-  --text: #101828;
-  --text-muted: #475467;
-  --accent: #0b7dda;
-  --accent-strong: #095ea6;
-  --shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  color-scheme: light;
+  --bg: linear-gradient(160deg, #0f1f2f 0%, #184a4f 45%, #1f6f5b 100%);
+  --panel-bg: rgba(246, 250, 248, 0.92);
+  --panel-border: rgba(15, 31, 47, 0.12);
+  --text: #0e1a26;
+  --text-muted: rgba(14, 26, 38, 0.62);
+  --accent: #1f6f5b;
+  --accent-strong: #1a5a49;
+  --shadow: 0 18px 36px rgba(15, 31, 47, 0.18);
   font-size: 16px;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --bg: #0f172a;
-    --panel-bg: rgba(15, 23, 42, 0.85);
-    --panel-border: rgba(148, 163, 184, 0.2);
-    --text: #e2e8f0;
-    --text-muted: #94a3b8;
-    --accent: #38bdf8;
-    --accent-strong: #0ea5e9;
-    --shadow: 0 10px 30px rgba(2, 6, 23, 0.4);
+    --panel-bg: rgba(15, 31, 47, 0.78);
+    --panel-border: rgba(111, 148, 151, 0.35);
+    --text: #e6f2f0;
+    --text-muted: rgba(230, 242, 240, 0.65);
+    --shadow: 0 18px 42px rgba(4, 12, 18, 0.5);
   }
 }
 
@@ -33,6 +30,7 @@ body {
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
     sans-serif;
   background: var(--bg);
+  background-attachment: fixed;
   color: var(--text);
   min-height: 100vh;
 }
@@ -43,9 +41,9 @@ body {
 }
 
 .site-header {
-  background: linear-gradient(135deg, #0ea5e9, #6366f1);
+  background: linear-gradient(135deg, rgba(27, 73, 101, 0.92), rgba(118, 200, 147, 0.88));
   color: white;
-  padding: 3.5rem 0 2.5rem;
+  padding: 3.75rem 0 2.75rem;
   margin-bottom: 2.5rem;
   position: relative;
   overflow: hidden;
@@ -55,8 +53,8 @@ body {
   content: '';
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at 20% -10%, rgba(255, 255, 255, 0.4), transparent),
-    radial-gradient(circle at 90% 20%, rgba(255, 255, 255, 0.3), transparent);
+  background: radial-gradient(circle at 15% -15%, rgba(255, 255, 255, 0.28), transparent),
+    radial-gradient(circle at 85% 30%, rgba(246, 250, 248, 0.22), transparent);
 }
 
 .site-header .wrap {
@@ -71,9 +69,9 @@ body {
 
 .tagline {
   margin: 0 0 1.75rem;
-  font-size: 1.15rem;
-  max-width: 48rem;
-  line-height: 1.6;
+  font-size: 1.2rem;
+  max-width: 36rem;
+  line-height: 1.55;
 }
 
 .controls {
@@ -90,26 +88,26 @@ body {
   font-weight: 600;
   font-size: 0.95rem;
   cursor: pointer;
-  background: rgba(255, 255, 255, 0.18);
+  background: rgba(246, 250, 248, 0.28);
   color: inherit;
   transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
-  backdrop-filter: blur(8px);
+  backdrop-filter: blur(10px);
 }
 
 .btn:hover,
 .btn:focus-visible {
   transform: translateY(-1px);
-  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.18);
+  box-shadow: 0 12px 28px rgba(11, 31, 38, 0.2);
 }
 
 .btn.primary {
-  background: white;
-  color: #0f172a;
+  background: #f6faf8;
+  color: var(--accent);
 }
 
 .btn.primary:hover,
 .btn.primary:focus-visible {
-  background: #f1f5f9;
+  background: #e8f5f0;
 }
 
 .hint {
@@ -166,14 +164,14 @@ main:not([data-empty]) .placeholder {
 }
 
 .placeholder .note {
-  margin-top: 1.5rem;
+  margin-top: 1.25rem;
   font-size: 0.95rem;
   color: var(--text-muted);
 }
 
 .panel {
   background: var(--panel-bg);
-  border-radius: 22px;
+  border-radius: 24px;
   border: 1px solid var(--panel-border);
   margin-bottom: 2rem;
   box-shadow: var(--shadow);
@@ -373,33 +371,6 @@ tbody td {
 .photo-card figcaption .meta {
   color: var(--text-muted);
   font-size: 0.85rem;
-}
-
-#dropOverlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(14, 165, 233, 0.25);
-  backdrop-filter: blur(6px);
-  display: grid;
-  place-items: center;
-  z-index: 999;
-}
-
-.overlay-content {
-  background: white;
-  color: #0f172a;
-  padding: 2.5rem 3rem;
-  border-radius: 24px;
-  box-shadow: var(--shadow);
-  font-size: 1.25rem;
-  font-weight: 600;
-}
-
-@media (prefers-color-scheme: dark) {
-  .overlay-content {
-    background: #111827;
-    color: #f1f5f9;
-  }
 }
 
 .empty-state {


### PR DESCRIPTION
## Summary
- streamline the hero copy and placeholder messaging for a sleeker loading experience
- remove the drag-and-drop overlay while keeping drop support intact
- refresh the global color palette to teal and seafoam tones that complement aquarium photography

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e25004c0a48323888b538b83835e35