### PR TITLE
Fix loading logic to run without header controls

### DIFF
--- a/aquatrack.js
+++ b/aquatrack.js
@@ -5,6 +5,56 @@ const measurementsSection = document.getElementById('measurementsSection');
 const eventsSection = document.getElementById('eventsSection');
 const photosSection = document.getElementById('photosSection');
 
+const LAST_URL_KEY = 'aquatrack:last-url';
+const LAST_FILE_KEY = 'aquatrack:last-file';
+
+let storageWarningShown = false;
+
+function setStatus(message, tone = 'info') {
+  const prefix = `[${tone}]`;
+  if (tone === 'error') {
+    console.error(`${prefix} ${message}`);
+  } else if (tone === 'warn' || tone === 'warning') {
+    console.warn(`${prefix} ${message}`);
+  } else {
+    console.log(`${prefix} ${message}`);
+  }
+}
+
+function storageGet(key) {
+  try {
+    return window.localStorage.getItem(key);
+  } catch (error) {
+    if (!storageWarningShown) {
+      console.warn('[storage] Unable to read key.', error);
+      storageWarningShown = true;
+    }
+    return null;
+  }
+}
+
+function storageSet(key, value) {
+  try {
+    window.localStorage.setItem(key, value);
+  } catch (error) {
+    if (!storageWarningShown) {
+      console.warn('[storage] Unable to persist data.', error);
+      storageWarningShown = true;
+    }
+  }
+}
+
+function storageRemove(key) {
+  try {
+    window.localStorage.removeItem(key);
+  } catch (error) {
+    if (!storageWarningShown) {
+      console.warn('[storage] Unable to remove stored data.', error);
+      storageWarningShown = true;
+    }
+  }
+}
+
 function clearContent() {
   for (const section of [
     tankSection,
@@ -343,8 +393,8 @@ function renderPhotos(photos = [], jsonBase, overrideBase) {
 function render(data, options = {}) {
   clearContent();
   if (!data || typeof data !== 'object') {
-    console.error('Invalid data: expected an object.');
-    return;
+    setStatus('Invalid data: expected an object.', 'error');
+    return false;
   }
 
   let hasContent = false;
@@ -365,6 +415,109 @@ function render(data, options = {}) {
 
   if (hasContent) {
     content.classList.add('has-data');
+  }
+
+  return hasContent;
+}
+
+async function loadFromUrl(url, photosBaseOverride, { successMessage } = {}) {
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Request failed with status ${response.status}`);
+    }
+    const data = await response.json();
+    render(data, { photosBase: photosBaseOverride });
+    storageSet(LAST_URL_KEY, url);
+    storageRemove(LAST_FILE_KEY);
+    setStatus(successMessage ?? `Loaded ${url}.`, 'info');
+    return true;
+  } catch (error) {
+    console.error(error);
+    setStatus(`Failed to load ${url}: ${error.message}`, 'error');
+    return false;
+  }
+}
+
+function loadFromFile(file, photosBaseOverride) {
+  const reader = new FileReader();
+  reader.addEventListener('load', () => {
+    try {
+      const text = String(reader.result ?? '');
+      const json = JSON.parse(text);
+      render(json, { photosBase: photosBaseOverride });
+      storageSet(LAST_FILE_KEY, text);
+      storageRemove(LAST_URL_KEY);
+      setStatus(`Loaded ${file.name}.`, 'info');
+    } catch (error) {
+      console.error(error);
+      setStatus(`Could not parse ${file.name}: ${error.message}`, 'error');
+    }
+  });
+  reader.addEventListener('error', () => {
+    setStatus(`Failed to read ${file.name}.`, 'error');
+  });
+  reader.readAsText(file);
+}
+
+function handleFiles(files, photosBaseOverride) {
+  if (!files?.length) return;
+  const [file] = files;
+  if (file.type && file.type !== 'application/json') {
+    setStatus('Please provide a JSON file.', 'error');
+    return;
+  }
+  loadFromFile(file, photosBaseOverride);
+}
+
+function handleDrop(event, photosBaseOverride) {
+  event.preventDefault();
+  handleFiles(event.dataTransfer?.files, photosBaseOverride);
+}
+
+async function init() {
+  const params = new URLSearchParams(window.location.search);
+  const dataParam = params.get('data');
+  const baseParam = params.get('base') ?? undefined;
+
+  document.addEventListener('dragover', (event) => {
+    event.preventDefault();
+  });
+  document.addEventListener('drop', (event) => handleDrop(event, baseParam));
+
+  if (dataParam) {
+    const url = decodeURIComponent(dataParam);
+    if (!(await loadFromUrl(url, baseParam, { successMessage: `Loaded ${url}.` }))) {
+      render(DEFAULT_DATA);
+      setStatus('Showing bundled sample data.', 'warning');
+    }
+    return;
+  }
+
+  const storedFile = storageGet(LAST_FILE_KEY);
+  if (storedFile) {
+    try {
+      const json = JSON.parse(storedFile);
+      render(json, { photosBase: baseParam });
+      setStatus('Loaded most recent local file.', 'info');
+      return;
+    } catch (error) {
+      console.error(error);
+      storageRemove(LAST_FILE_KEY);
+    }
+  }
+
+  const storedUrl = storageGet(LAST_URL_KEY);
+  if (storedUrl) {
+    if (await loadFromUrl(storedUrl, baseParam, { successMessage: `Loaded ${storedUrl}.` })) {
+      return;
+    }
+    storageRemove(LAST_URL_KEY);
+  }
+
+  if (!(await loadFromUrl('aquatrack.json', baseParam, { successMessage: 'Loaded aquatrack.json.' }))) {
+    render(DEFAULT_DATA);
+    setStatus('Showing bundled sample data.', 'warning');
   }
 }
 
@@ -428,4 +581,4 @@ const DEFAULT_DATA = {
   photos: [],
 };
 
-render(DEFAULT_DATA);
+init();


### PR DESCRIPTION
## Summary
- remove DOM references to the deleted header controls and add console-based status logging
- keep JSON loading via URL or drag-and-drop with storage fallbacks and default sample data

## Testing
- node --check aquatrack.js

------
https://chatgpt.com/codex/tasks/task_e_68e257f694cc8323a295a3c42396e0f9